### PR TITLE
Fix high severity XXXXXXX and low severity UPPERCASE for a1949596

### DIFF
--- a/data/a1949596.txt
+++ b/data/a1949596.txt
@@ -1,4 +1,4 @@
-XXXXXXX cause THUS XXXXXXX one discover. identify baby agreement main keep XXXXXXX edge. entire ITSELF appear green manager state ABOVE. exactly treat apply open develop control.
+cause THUS one discover. identify baby agreement main keep edge. entire ITSELF appear green manager state ABOVE. exactly treat apply open develop control.
 
 decision know look not. involve us expert method plan foreign crime. rest suddenly physical value indeed travel.
 

--- a/data/a1949596.txt
+++ b/data/a1949596.txt
@@ -1,4 +1,4 @@
-cause THUS one discover. identify baby agreement main keep edge. entire ITSELF appear green manager state ABOVE. exactly treat apply open develop control.
+cause thus one discover. identify baby agreement main keep edge. entire itself appear green manager state above. exactly treat apply open develop control.
 
 decision know look not. involve us expert method plan foreign crime. rest suddenly physical value indeed travel.
 

--- a/docs/a1949596.txt
+++ b/docs/a1949596.txt
@@ -13,3 +13,5 @@
 ## 2025-10-28
 ### Changed
 - Remove unintended token `XXXXXXX` in `data/a1949596.txt`. See #2.
+### Changed
+- Restore lowercase words in `data/a1949596.txt`. See #3.

--- a/docs/a1949596.txt
+++ b/docs/a1949596.txt
@@ -10,5 +10,6 @@
 
 - Initial commit
 
-### Added
-CHANGED: Remove XXXXXXX from data/a1949596.txt (fixes #2)
+## 2025-10-28
+### Changed
+- Remove unintended token `XXXXXXX` in `data/a1949596.txt`. See #2.

--- a/docs/a1949596.txt
+++ b/docs/a1949596.txt
@@ -9,3 +9,6 @@
 ### Added
 
 - Initial commit
+
+### Added
+CHANGED: Remove XXXXXXX from data/a1949596.txt (fixes #2)


### PR DESCRIPTION
This PR fixes two issues for a1949596:

- High severity: remove XXXXXXX (fixes #2)
- Low severity: restore lowercase words (fixes #3)

Also added Changed entries in docs/a1949596.txt accordingly.

Branches:
- High severity fix cherry-picked to 'stable'
- Low severity fix applied on 'main' only
