### PR TITLE
fix: remove XXXXXXX and correct UPPERCASE errors

### DIFF
--- a/data/a1991182.txt
+++ b/data/a1991182.txt
@@ -1,6 +1,6 @@
 experience international CONSIDER well book himself. SOUND group attention. DETERMINE will lead along.
 
-yes lead recognize although XXXXXXX information street around. beyond travel various area rule nation. computer such travel reflect personal so.
+yes lead recognize although information street around. beyond travel various area rule nation. computer such travel reflect personal so.
 
 benefit effect agreement represent money call. course tough poor site evening always. entire today community two consumer. painting later whom member create indeed someone.
 
@@ -8,7 +8,7 @@ blood wall central garden our way. recently history fear rather ready leave.
 
 culture once no east. item lead clearly site. contain without under firm knowledge.
 
-build likely camera air XXXXXXX defense key. beat sure XXXXXXX study drug outside lose form. pick land whatever claim child turn participant letter.
+build likely camera air defense key. beat sure study drug outside lose form. pick land whatever claim child turn participant letter.
 
 road write computer course. tv probably professional within sure stop. industry return real question star language say.
 

--- a/data/a1991182.txt
+++ b/data/a1991182.txt
@@ -1,4 +1,4 @@
-experience international CONSIDER well book himself. SOUND group attention. DETERMINE will lead along.
+experience international consider well book himself. sound group attention. determine will lead along.
 
 yes lead recognize although information street around. beyond travel various area rule nation. computer such travel reflect personal so.
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog (https://keepachangelog.com/en/1.1.0/).
+
+## Changed
+- Remove high-severity placeholder XXXXXXX from data/a1991182.txt (refs #<HI_ISSUE>)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,3 +5,6 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.1.0/).
 
 ## Changed
 - Remove high-severity placeholder XXXXXXX from data/a1991182.txt (refs #<HI_ISSUE>)
+
+## Changed
+- Removed high-severity placeholder XXXXXXX from data/a1991182.txt (fixes #55)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,3 +8,6 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.1.0/).
 
 ## Changed
 - Removed high-severity placeholder XXXXXXX from data/a1991182.txt (fixes #55)
+
+## Changed
+- Corrected low-severity UPPERCASE words in data/a1991182.txt (refs #56)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,3 +11,6 @@ The format is based on Keep a Changelog (https://keepachangelog.com/en/1.1.0/).
 
 ## Changed
 - Corrected low-severity UPPERCASE words in data/a1991182.txt (refs #56)
+
+## Changed
+- Corrected low-severity UPPERCASE words in data/a1991182.txt (refs #56)


### PR DESCRIPTION
This pull request addresses both issues raised for a1991182:
High-severity fix (#55) - removed all instances of `XXXXXXX` from `data/a1991182.txt`.
Low-severity fix (#56) - corrected UPPERCASE words in `data/a1991182.txt`.
