### PR TITLE
Fixed: high severity bug (XXXXXXX insertions) and low severity bug (uppercase words) in data/a1822446

### DIFF
--- a/data/a1822446.txt
+++ b/data/a1822446.txt
@@ -1,6 +1,6 @@
 growth without save yeah serve. interview new spend should analysis.
 
-EITHER color think XXXXXXX strong. AFFECT leader door XXXXXXX change perform tree.
+EITHER color think strong. AFFECT leader door change perform tree.
 
 purpose understand mrs common those station pattern. sound catch night sure recently beyond speech.
 
@@ -10,7 +10,7 @@ reflect loss writer successful without HAVE thing.
 
 size world relationship model skill firm debate. of size outside them not.
 
-task XXXXXXX imagine authority eat. body glass wrong she evidence tax cup. win strong wind success.
+task imagine authority eat. body glass wrong she evidence tax cup. win strong wind success.
 
 reveal chair building. tend thought of wind exist indicate grow.
 

--- a/data/a1822446.txt
+++ b/data/a1822446.txt
@@ -1,12 +1,12 @@
 growth without save yeah serve. interview new spend should analysis.
 
-EITHER color think strong. AFFECT leader door change perform tree.
+either color think strong. affect leader door change perform tree.
 
 purpose understand mrs common those station pattern. sound catch night sure recently beyond speech.
 
 size fund among up paper can. become leave we dream. hard conference have fill sometimes would do behind. true vote surface.
 
-reflect loss writer successful without HAVE thing.
+reflect loss writer successful without have thing.
 
 size world relationship model skill firm debate. of size outside them not.
 

--- a/docs/a1822446.txt
+++ b/docs/a1822446.txt
@@ -12,3 +12,5 @@
 
 ### Changed
 - Removed high severity bug from file data/a1822446.txt (XXXXXXX)
+
+- Amended low severity bug in file data/a1822446.txt (uppercase words)

--- a/docs/a1822446.txt
+++ b/docs/a1822446.txt
@@ -9,3 +9,6 @@
 ### Added
 
 - Initial commit
+
+### Changed
+- Removed high severity bug from file data/a1822446.txt (XXXXXXX)


### PR DESCRIPTION
This pull requests relates to two earlier issues raised and linked below regarding the file `data/a1822446.txt`

- Removed high severity bug `XXXXXXX` insertion and pushed to both main and stable branches https://github.com/davmlaw/2025_assessment_6_version_control/issues/91

- Amended low severity bug by changing uppercase back to lowercase and pushed to main branch only (https://github.com/davmlaw/2025_assessment_6_version_control/issues/92)

Cheers :)