### PR TITLE
Fix high and low severity issues in a1957056.txt

### DIFF
--- a/data/a1957056.txt
+++ b/data/a1957056.txt
@@ -1,10 +1,10 @@
 present rich include wait leg represent. race well include usually positive management.
 
-party us your XXXXXXX before old. want XXXXXXX figure BETTER whole REALIZE real ELECTION.
+party us your before old. want figure BETTER whole REALIZE real ELECTION.
 
 really grow be expect. away visit response person weight short. try day country move miss growth.
 
-XXXXXXX look forget and its. should debate him television bag modern. have to event west fight total.
+look forget and its. should debate him television bag modern. have to event west fight total.
 
 enjoy attention among successful. yeah enough understand church from. card process various major oil culture go. per stage community consider discussion.
 

--- a/data/a1957056.txt
+++ b/data/a1957056.txt
@@ -1,6 +1,6 @@
 present rich include wait leg represent. race well include usually positive management.
 
-party us your before old. want figure BETTER whole REALIZE real ELECTION.
+party us your before old. want figure better whole realize real election.
 
 really grow be expect. away visit response person weight short. try day country move miss growth.
 

--- a/docs/a1957056.txt
+++ b/docs/a1957056.txt
@@ -12,4 +12,8 @@
 
 # CHANGED:
 
-- Fixed high severity XXXXXXX placeholders in data/a1957056.txt (#100).
+-CHANGED: Fixed high severity XXXXXXX placeholders in data/a1957056.txt (#100).
+
+#CHANGED
+
+- CHANGED: Fixed low severity UPPERCASE bug (BETTER, REALIZE, ELECTION) in data/a1957056.txt (#103).

--- a/docs/a1957056.txt
+++ b/docs/a1957056.txt
@@ -9,3 +9,7 @@
 ### Added
 
 - Initial commit
+
+# CHANGED:
+
+- Fixed high severity XXXXXXX placeholders in data/a1957056.txt (#100).


### PR DESCRIPTION
This pull request fixes both of my assigned issues for data/a1957056.txt:

- Fixes #100  (high severity XXXXXXX placeholders)
- Fixes #103  (low severity UPPERCASE bug)

Summary of changes:
- On main:
  - Removed the XXXXXXX placeholders from data/a1957056.txt and added a CHANGED entry to doc/a1957056.txt referencing the high severity issue.
  - Corrected BETTER, REALIZE and ELECTION to lowercase (better, realize, election) in data/a1957056.txt and added a CHANGED entry referencing the low severity issue.
- On stable:
  - Cherry-picked the high severity XXXXXXX fix so that the critical bug is also resolved in the stable branch.

