### PR TITLE
Fix high severity XXXXXXX bug and low severity UPPERCASE bug in data/a1864358.txt

### DIFF
--- a/data/a1864358.txt
+++ b/data/a1864358.txt
@@ -1,8 +1,8 @@
 cut man wall law as which. term special couple. modern agree so attorney. believe where any out shoulder.
 
-term LAWYER feeling see XXXXXXX weight. go XXXXXXX thus still represent here.
+term LAWYER feeling see weight. go thus still represent here.
 
-XXXXXXX water hot speech feel describe knowledge daughter point. newspaper REAL GO move poor leg property. receive table into professor hard guess bad.
+water hot speech feel describe knowledge daughter point. newspaper REAL GO move poor leg property. receive table into professor hard guess bad.
 
 business employee catch and. what gun hot still plant. city read political anything would everybody.
 

--- a/data/a1864358.txt
+++ b/data/a1864358.txt
@@ -1,8 +1,8 @@
 cut man wall law as which. term special couple. modern agree so attorney. believe where any out shoulder.
 
-term LAWYER feeling see weight. go thus still represent here.
+term lawyer feeling see weight. go thus still represent here.
 
-water hot speech feel describe knowledge daughter point. newspaper REAL GO move poor leg property. receive table into professor hard guess bad.
+water hot speech feel describe knowledge daughter point. newspaper real go move poor leg property. receive table into professor hard guess bad.
 
 business employee catch and. what gun hot still plant. city read political anything would everybody.
 

--- a/docs/a1864358.txt
+++ b/docs/a1864358.txt
@@ -1,5 +1,9 @@
 ## [unreleased]
 
+### Changed
+
+- Fixed high severity XXXXXXX bug in data/a1864358.txt. See Issue #62
+
 ### Added
 
 - [Generate initial text files for students](https://github.com/davmlaw/2025_assessment_6_version_control/issues/1) - including initial errors

--- a/docs/a1864358.txt
+++ b/docs/a1864358.txt
@@ -2,6 +2,10 @@
 
 ### Changed
 
+- Fixed low severity UPERCASE bug in data/a1864358.txt. See Issue $63
+
+### Changed
+
 - Fixed high severity XXXXXXX bug in data/a1864358.txt. See Issue #62
 
 ### Added


### PR DESCRIPTION
Hello,

This pull request fixes both the high severity XXXXXXX bug (Issue #62) and the low severity UPPERCASE bug (Issue #63) in data/a1864358.txt.

The high severity fix removes the XXXXXXX insertion.

The low severity fix converts unwanted uppercase words back to lowercase.

Both fixes include updates to the changelog docs/a1864358.txt with appropriate references to these issues.

Regards,

A1864358