### PR TITLE
Fix XXXXXXX and UPPERCASE bugs for data/a1975386.txt

### DIFF
--- a/data/a1975386.txt
+++ b/data/a1975386.txt
@@ -1,4 +1,4 @@
-XXXXXXX whether suddenly XXXXXXX their agree middle XXXXXXX arrive FINANCIAL. method TABLE BEFORE. term hair partner close.
+whether suddenly their agree middle arrive FINANCIAL. method TABLE BEFORE. term hair partner close.
 
 theory camera nice season general number shoulder. record technology hour who personal.
 

--- a/data/a1975386.txt
+++ b/data/a1975386.txt
@@ -1,4 +1,4 @@
-whether suddenly their agree middle arrive FINANCIAL. method TABLE BEFORE. term hair partner close.
+whether suddenly their agree middle arrive financial. method table before. term hair partner close.
 
 theory camera nice season general number shoulder. record technology hour who personal.
 

--- a/docs/a1975386.txt
+++ b/docs/a1975386.txt
@@ -4,6 +4,8 @@
 
 Removed XXXXXXX insertion from `data/a1975386.txt` (refs #122)
 
+Fixed accidental UPPERCASE words in `data/a1975386.txt` (refs #123)
+
 ### Added
 
 - [Generate initial text files for students](https://github.com/davmlaw/2025_assessment_6_version_control/issues/1) - including initial errors

--- a/docs/a1975386.txt
+++ b/docs/a1975386.txt
@@ -1,5 +1,9 @@
 ## [unreleased]
 
+### Changed
+
+Removed XXXXXXX insertion from `data/a1975386.txt` (refs #122)
+
 ### Added
 
 - [Generate initial text files for students](https://github.com/davmlaw/2025_assessment_6_version_control/issues/1) - including initial errors


### PR DESCRIPTION
This pull request fixes two issues in my assigned files:

- High severity XXXXXXX insertion in `data/a1975386.txt` (refs #122)
- Low severity UPPERCASE words in `data/a1975386.txt` (refs #123)

Both changes are documented in `docs/a1975386.txt` following the changelog format.

Thank you for reviewing my changes.