### PR TITLE
Fixed : High severity issues of XXXXXXX placeholder (#132) and low severity issues of UPPERCASE words (#133) in data/a1979858.txt

### DIFF
--- a/data/a1979858.txt
+++ b/data/a1979858.txt
@@ -1,10 +1,10 @@
-OPERATION admit spring. page serious know area fill project standard.
+operation admit spring. page serious know area fill project standard.
 
 firm responsibility trouble player. home especially maybe red wrong traditional stay.
 
-huge BUILD thus decision writer congress.
+huge build thus decision writer congress.
 
-call HIMSELF final star. certainly financial open institution upon. foot know research wind sing. population participant design either agreement upon talk.
+call himself final star. certainly financial open institution upon. foot know research wind sing. population participant design either agreement upon talk.
 
 food head party rest. we tell energy mother.
 

--- a/data/a1979858.txt
+++ b/data/a1979858.txt
@@ -1,8 +1,8 @@
-OPERATION admit spring. XXXXXXX page serious know area fill project standard.
+OPERATION admit spring. page serious know area fill project standard.
 
-firm responsibility trouble XXXXXXX player. home especially maybe red wrong traditional stay.
+firm responsibility trouble player. home especially maybe red wrong traditional stay.
 
-XXXXXXX huge BUILD thus decision writer congress.
+huge BUILD thus decision writer congress.
 
 call HIMSELF final star. certainly financial open institution upon. foot know research wind sing. population participant design either agreement upon talk.
 

--- a/docs/a1979858.txt
+++ b/docs/a1979858.txt
@@ -9,3 +9,6 @@
 ### Added
 
 - Initial commit
+
+### Changed
+- [Fix XXXXXXX issues in line 1 3 5](https://github.com/davmlaw/2025_assessment_6_version_control/issues/132) - delete the bug leaving 1 space between each word

--- a/docs/a1979858.txt
+++ b/docs/a1979858.txt
@@ -12,3 +12,6 @@
 
 ### Changed
 - [Fix XXXXXXX issues in line 1 3 5](https://github.com/davmlaw/2025_assessment_6_version_control/issues/132) - delete the bug leaving 1 space between each word
+
+### Changed
+- [Fix UPPERCASE issue in lines 1 5 and 7](https://github.com/davmlaw/2025_assessment_6_version_control/issues/133) - change to lowercase


### PR DESCRIPTION
This is the request mentioned in issues reported in #132 and #133 

I have fixed both issues found in data/a1979858.txt as follows:

High severity bug (#132) with commit 897da14, and add changelog with commit: 3dc1657 while in stable branch with commit 1d64ac9
: XXXXXXX placeholders in line 1,3 and 5 are removed, and maintain 1 space between words.

Low severity bug (#133) with commit a052392, and add changelog with commit: b3b1d53
: "OPERATION" in line 1 , "BUILD"  in line 5 and "HIMSELF" in line 7, which were previously written in uppercase, were changed into lowercase.

