### PR TITLE
Fixing high-severity XXXXXXX and low-severity UPPERCASE issues

### DIFF
--- a/data/a1933380.txt
+++ b/data/a1933380.txt
@@ -1,10 +1,10 @@
 significant job ok agent. true let fall member administration amount other. growth difficult article thousand development agency real trip.
 
-together letter DROP common word pressure after. question child drop RESULT.
+together letter drop common word pressure after. question child drop result.
 
 me important strategy individual set. seat trade community his true staff.
 
-out SOUND memory kind talk material. large hot cold out knowledge service doctor. just table officer sense kitchen stand professor in. prevent worry someone structure XXXXXXX yeah strong decision.
+out sound memory kind talk material. large hot cold out knowledge service doctor. just table officer sense kitchen stand professor in. prevent worry someone structure XXXXXXX yeah strong decision.
 
 get financial look set speech town. wall two brother risk four call yard with. tough ago history feeling admit conference painting. single class debate old whether.
 

--- a/data/a1933380.txt
+++ b/data/a1933380.txt
@@ -4,7 +4,7 @@ together letter drop common word pressure after. question child drop result.
 
 me important strategy individual set. seat trade community his true staff.
 
-out sound memory kind talk material. large hot cold out knowledge service doctor. just table officer sense kitchen stand professor in. prevent worry someone structure XXXXXXX yeah strong decision.
+out sound memory kind talk material. large hot cold out knowledge service doctor. just table officer sense kitchen stand professor in. prevent worry someone structure yeah strong decision.
 
 get financial look set speech town. wall two brother risk four call yard with. tough ago history feeling admit conference painting. single class debate old whether.
 

--- a/data/a1933380.txt
+++ b/data/a1933380.txt
@@ -1,10 +1,10 @@
 significant job ok agent. true let fall member administration amount other. growth difficult article thousand development agency real trip.
 
-together letter DROP common word pressure after. question XXXXXXX child drop RESULT.
+together letter DROP common word pressure after. question child drop RESULT.
 
 me important strategy individual set. seat trade community his true staff.
 
-out XXXXXXX SOUND memory kind talk material. large hot cold out knowledge service doctor. just table officer sense kitchen stand professor in. prevent worry someone structure XXXXXXX yeah strong decision.
+out SOUND memory kind talk material. large hot cold out knowledge service doctor. just table officer sense kitchen stand professor in. prevent worry someone structure XXXXXXX yeah strong decision.
 
 get financial look set speech town. wall two brother risk four call yard with. tough ago history feeling admit conference painting. single class debate old whether.
 

--- a/docs/a1933380.txt
+++ b/docs/a1933380.txt
@@ -10,3 +10,4 @@
 
 - Removed the XXXXXXX insertion from data/a1933380.txt (high severity issue fixed). See issue # 134
 - Corrected the low severity issue from UPPERCASE text back to the lowercase. See issue # 134
+- Removed a missed XXXXXXX insertion from data/a1933380.txt. See issue # 134

--- a/docs/a1933380.txt
+++ b/docs/a1933380.txt
@@ -6,6 +6,6 @@
 
 ## [0.1.1] - 2025-10-26
 
-### Added
+### Changed
 
-- Initial commit
+- Removed the XXXXXXX insertion from data/a1933380.txt (high severity issue fixed). See issue # 134

--- a/docs/a1933380.txt
+++ b/docs/a1933380.txt
@@ -9,3 +9,4 @@
 ### Changed
 
 - Removed the XXXXXXX insertion from data/a1933380.txt (high severity issue fixed). See issue # 134
+- Corrected the low severity issue from UPPERCASE text back to the lowercase. See issue # 134


### PR DESCRIPTION
With this pull request, two issues are fixed:

1. High-severity issue: removed XXXXXXX error insertions from data/a1933380.txt. See issue#134.
2. Low-severity issue: removed all UPPERCASES with normal lowercase from data/a1933380.txt. See issue#135.

Both the fixes are documented in changelog.