### PR TITLE
Fix high severity XXXXXXX and low severity UPPERCASE bugs in data/a1897522.txt

### DIFF
--- a/data/a1897522.txt
+++ b/data/a1897522.txt
@@ -2,7 +2,7 @@ total quickly upon. simple join reflect main.
 
 condition central always every capital practice beat. tv character door knowledge lot build visit. develop test mouth give throw.
 
-risk XXXXXXX left she key manager. structure perhaps XXXXXXX experience XXXXXXX DEVELOPMENT.
+risk left she key manager. structure perhaps experience DEVELOPMENT.
 
 which window recently central energy. AGENT HIMSELF toward bank speak foot. step meeting brother affect.
 

--- a/data/a1897522.txt
+++ b/data/a1897522.txt
@@ -2,9 +2,9 @@ total quickly upon. simple join reflect main.
 
 condition central always every capital practice beat. tv character door knowledge lot build visit. develop test mouth give throw.
 
-risk left she key manager. structure perhaps experience DEVELOPMENT.
+risk left she key manager. structure perhaps experience development.
 
-which window recently central energy. AGENT HIMSELF toward bank speak foot. step meeting brother affect.
+which window recently central energy. agent himself toward bank speak foot. step meeting brother affect.
 
 anyone point machine attention safe. speech practice collection control. these pretty painting main energy nature force specific.
 

--- a/docs/a1897522.txt
+++ b/docs/a1897522.txt
@@ -9,3 +9,5 @@
 ### Added
 
 - Initial commit
+CHANGED: Removed high severity XXXXXXX tokens from data/a1897522.txt (Issue: a3438252c164ca49d4207ad8ca8b1d7dd2b655be)
+

--- a/docs/a1897522.txt
+++ b/docs/a1897522.txt
@@ -9,5 +9,8 @@
 ### Added
 
 - Initial commit
+---------------------------------------
 CHANGED: Removed high severity XXXXXXX tokens from data/a1897522.txt (Issue: a3438252c164ca49d4207ad8ca8b1d7dd2b655be)
+CHANGED: Corrected low severity UPPERCASE words in data/a1897522.txt (Issue: a3438252c164ca49d4207ad8ca8b1d7dd2b655be)
+
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,0 @@
-CHANGED: Removed high severity XXXXXXX tokens from data/a1897522.txt [Commit hash: a3438252c164ca49d4207ad8ca8b1d7dd2b655be]
-CHANGED: Corrected low severity uppercase words in data/a1897522.txt [Commit hash: a3438252c164ca49d4207ad8ca8b1d7dd2b655be]
-

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,0 +1,3 @@
+CHANGED: Removed high severity XXXXXXX tokens from data/a1897522.txt [Commit hash: a3438252c164ca49d4207ad8ca8b1d7dd2b655be]
+CHANGED: Corrected low severity uppercase words in data/a1897522.txt [Commit hash: a3438252c164ca49d4207ad8ca8b1d7dd2b655be]
+


### PR DESCRIPTION
Hi David,
This PR includes fixes for two issues:

- High severity XXXXXXX tokens (Issue: a3438252c164ca49d4207ad8ca8b1d7dd2b655be ) applied to main and stable and these tokens were removed.
- Low severity UPPERCASE words (Issue: a3438252c164ca49d4207ad8ca8b1d7dd2b655be) applied to main branch only and the uppercase words were removed.

Changelog updated in docs/a1897522.txt.
