### PR TITLE
Final Fixes for High and Low Severity Issues in a1974970.txt

### DIFF
--- a/bin/changelog_template
+++ b/bin/changelog_template
@@ -13,3 +13,4 @@
 ### FIXED
 
 - Fixed high-severity XXXXXXX placeholder bug in data/a1974970.txt. Addresses issue #164.
+- Corrected inconsistent casing of words(UPPERCASE to lowercase) in data/a1974970.txt. Addresses issue #165.

--- a/bin/changelog_template
+++ b/bin/changelog_template
@@ -9,3 +9,7 @@
 ### Added
 
 - Initial commit
+
+### FIXED
+
+- Fixed high-severity XXXXXXX placeholder bug in data/a1974970.txt. Addresses issue #164.

--- a/data/a1974970.txt
+++ b/data/a1974970.txt
@@ -1,4 +1,4 @@
-XXXXXXX particular concern PREVENT XXXXXXX look without ANOTHER. XXXXXXX material OFFER statement official.
+particular concern PREVENT look without ANOTHER. material OFFER statement official.
 
 life total two network. road race stage give case. leave make reality start in.
 

--- a/data/a1974970.txt
+++ b/data/a1974970.txt
@@ -1,4 +1,4 @@
-particular concern PREVENT look without ANOTHER. material OFFER statement official.
+particular concern prevent look without another. material offer statement official.
 
 life total two network. road race stage give case. leave make reality start in.
 


### PR DESCRIPTION
Hello Maintainers,

This Pull Request consolidates both required fixes for the assignment, applying them to the `main` branch:

1.  **High-Severity Fix:** Removed the 'XXXXXXX' placeholders and added a changelog entry.
2.  **Low-Severity Fix:** Corrected the remaining inconsistent casing (UPPERCASE to lowercase) and updated the changelog.

Both issues are addressed and can be automatically closed upon merging:

* Closes #164 (High Severity: XXXXXXX placeholder bug)
* Closes #165 (Low Severity: UPPERCASE casing bug)

Thank you!