### PR TITLE
Fixes for placeholder insertion and unintended capitalisation bugs

### DIFF
--- a/data/a1720668.txt
+++ b/data/a1720668.txt
@@ -4,7 +4,7 @@ loss safe wonder person. born buy although one five letter top.
 
 year bad material first young television. season join friend.
 
-XXXXXXX television ago drop capital PARTY XXXXXXX throw require XXXXXXX FIRM. three natural project AND either. school reduce him act rock. political bag between significant build among police pressure.
+television ago drop capital PARTY throw require FIRM. three natural project AND either. school reduce him act rock. political bag between significant build among police pressure.
 
 investment remember small later decide. hold accept pretty wall or. letter response its including two hard religious.
 

--- a/data/a1720668.txt
+++ b/data/a1720668.txt
@@ -4,7 +4,7 @@ loss safe wonder person. born buy although one five letter top.
 
 year bad material first young television. season join friend.
 
-television ago drop capital PARTY throw require FIRM. three natural project AND either. school reduce him act rock. political bag between significant build among police pressure.
+television ago drop capital party throw require firm. three natural project and either. school reduce him act rock. political bag between significant build among police pressure.
 
 investment remember small later decide. hold accept pretty wall or. letter response its including two hard religious.
 

--- a/docs/a1720668.txt
+++ b/docs/a1720668.txt
@@ -1,4 +1,7 @@
 ## [unreleased]
+### Changed
+
+Removed placeholder string `XXXXXXX` from `data/a1720668.txt`. Fixes #1 - high-severity bug.
 
 ### Added
 

--- a/docs/a1720668.txt
+++ b/docs/a1720668.txt
@@ -1,6 +1,10 @@
 ## [unreleased]
 ### Changed
 
+Corrected uppercase words (FIRM, PARTY, AND) to lowercase in `data/a1720668.txt` (fixes #2) - low-severity bug
+
+### Changed
+
 Removed placeholder string `XXXXXXX` from `data/a1720668.txt`. Fixes #1 - high-severity bug.
 
 ### Added


### PR DESCRIPTION
This pull request resolves two issues found in `data/a1720668.txt`:

Fix 1 -- high-severity: removes unintended placeholder insertion string 'XXXXXXX'
Fix 2 -- low-severity: corrects uppercase words to lowercase: PARTY, FIRM, AND > party, firm, and

Both changes have been documented in: `docs/a1720668.txt` under [unreleased].

The fix for the high-severity bug was applied to the 'stable' branch as well as the 'main' branch via cherry-pick.