### PR TITLE
Fixes #207 and #208: Remove XXXXXXX and normalize case in a1894721.txt with updated changelog

### DIFF
--- a/data/a1894721.txt
+++ b/data/a1894721.txt
@@ -1,18 +1,18 @@
 size popular tv glass. benefit behavior son theory. become front too pull actually.
 
-least catch XXXXXXX sound.
+least catch sound.
 
 author phone really lose though.
 
 investment lay begin pick scientist. whom page response oil south green class go.
 
-worry BELIEVE series. second team relationship debate XXXXXXX land cell economic.
+worry BELIEVE series. second team relationship debate land cell economic.
 
 new check anyone network walk step kid. staff blue practice allow government arm.
 
 true improve arm fish carry. seem expert send full. else none suggest summer police evening us world.
 
-XXXXXXX run son whose DEBATE. PERHAPS activity trade mouth red.
+run son whose DEBATE. PERHAPS activity trade mouth red.
 
 prove perform person capital church. pretty statement suggest another. effect money debate instead hair moment.
 

--- a/data/a1894721.txt
+++ b/data/a1894721.txt
@@ -6,13 +6,13 @@ author phone really lose though.
 
 investment lay begin pick scientist. whom page response oil south green class go.
 
-worry BELIEVE series. second team relationship debate land cell economic.
+worry believe series. second team relationship debate land cell economic.
 
 new check anyone network walk step kid. staff blue practice allow government arm.
 
 true improve arm fish carry. seem expert send full. else none suggest summer police evening us world.
 
-run son whose DEBATE. PERHAPS activity trade mouth red.
+run son whose debate. perhaps activity trade mouth red.
 
 prove perform person capital church. pretty statement suggest another. effect money debate instead hair moment.
 

--- a/docs/a1894721.txt
+++ b/docs/a1894721.txt
@@ -8,6 +8,10 @@
 
 - [Remove high severity issue XXXXXXX insertions from data/a1894721.txt](https://github.com/davmlaw/2025_assessment_6_version_control/issues/207) - corrected lines 3, 9, and 15
 
+### Changed
+
+- [Case sensitivity inconsistencies in data/a1894721.txt](https://github.com/davmlaw/2025_assessment_6_version_control/issues/208) - normalized BELIEVE/DEBATE/PERHAPS to lowercase
+
 ## [0.1.1] - 2025-10-26
 
 ### Added

--- a/docs/a1894721.txt
+++ b/docs/a1894721.txt
@@ -4,6 +4,10 @@
 
 - [Generate initial text files for students](https://github.com/davmlaw/2025_assessment_6_version_control/issues/1) - including initial errors
 
+### Changed
+
+- [Remove high severity issue XXXXXXX insertions from data/a1894721.txt](https://github.com/davmlaw/2025_assessment_6_version_control/issues/207) - corrected lines 3, 9, and 15
+
 ## [0.1.1] - 2025-10-26
 
 ### Added


### PR DESCRIPTION
This pull request addresses two issues in the dataset:

- Fixes #207 : Removed unintended XXXXXXX entries from `data/a1894721.txt`.
  - Corrected lines 3, 9, and 15.
  - Updated `doc/a1894721.txt` accordingly.

- Fixes #208 : Normalized case inconsistencies in `data/a1894721.txt`.
  - Converted BELIEVE/DEBATE/PERHAPS to lowercase.
  - Updated `doc/a1894721.txt` accordingly.

Both fixes are included in this single PR as per assignment requirements.
